### PR TITLE
Provide methods to recycle thumbnails and raw images

### DIFF
--- a/app/src/main/java/com/bilibili/boxing/impl/BoxingGlideLoader.java
+++ b/app/src/main/java/com/bilibili/boxing/impl/BoxingGlideLoader.java
@@ -24,6 +24,7 @@ import android.widget.ImageView;
 import com.bilibili.boxing.demo.R;
 import com.bilibili.boxing.loader.IBoxingCallback;
 import com.bilibili.boxing.loader.IBoxingMediaLoader;
+import com.bilibili.boxing.loader.IBoxingMediaRecyclingLoader;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.request.RequestListener;
 import com.bumptech.glide.request.target.Target;
@@ -34,7 +35,7 @@ import com.bumptech.glide.request.target.Target;
  *
  * @author ChenSL
  */
-public class BoxingGlideLoader implements IBoxingMediaLoader {
+public class BoxingGlideLoader implements IBoxingMediaRecyclingLoader {
 
     @Override
     public void displayThumbnail(@NonNull ImageView img, @NonNull String absPath, int width, int height) {
@@ -42,7 +43,7 @@ public class BoxingGlideLoader implements IBoxingMediaLoader {
         try {
             // https://github.com/bumptech/glide/issues/1531
             Glide.with(img.getContext()).load(path).placeholder(R.drawable.ic_boxing_default_image).crossFade().centerCrop().into(img);
-        } catch(IllegalArgumentException ignore) {
+        } catch (IllegalArgumentException ignore) {
         }
 
     }
@@ -77,4 +78,13 @@ public class BoxingGlideLoader implements IBoxingMediaLoader {
 
     }
 
+    @Override
+    public void recycleThumbnail(@NonNull ImageView img, @NonNull String absPath) {
+        Glide.clear(img);
+    }
+
+    @Override
+    public void recycleRaw(@NonNull ImageView img, @NonNull String absPath) {
+        Glide.clear(img);
+    }
 }

--- a/boxing-impl/src/main/java/com/bilibili/boxing_impl/adapter/BoxingMediaAdapter.java
+++ b/boxing-impl/src/main/java/com/bilibili/boxing_impl/adapter/BoxingMediaAdapter.java
@@ -113,6 +113,13 @@ public class BoxingMediaAdapter extends RecyclerView.Adapter {
     }
 
     @Override
+    public void onViewRecycled(RecyclerView.ViewHolder holder) {
+        if (holder instanceof ImageViewHolder) {
+            ((ImageViewHolder) holder).mItemLayout.recycleMedia();
+        }
+    }
+
+    @Override
     public long getItemId(int position) {
         return position;
     }

--- a/boxing-impl/src/main/java/com/bilibili/boxing_impl/ui/BoxingBottomSheetActivity.java
+++ b/boxing-impl/src/main/java/com/bilibili/boxing_impl/ui/BoxingBottomSheetActivity.java
@@ -32,6 +32,7 @@ import android.widget.ImageView;
 import com.bilibili.boxing.AbsBoxingActivity;
 import com.bilibili.boxing.AbsBoxingViewFragment;
 import com.bilibili.boxing.BoxingMediaLoader;
+import com.bilibili.boxing.loader.IBoxingMediaLoader;
 import com.bilibili.boxing.model.entity.BaseMedia;
 import com.bilibili.boxing.model.entity.impl.ImageMedia;
 import com.bilibili.boxing_impl.R;
@@ -48,6 +49,7 @@ import java.util.List;
 public class BoxingBottomSheetActivity extends AbsBoxingActivity implements View.OnClickListener {
     private BottomSheetBehavior<FrameLayout> mBehavior;
     private ImageView mImage;
+    private String mImagePath = "";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -152,9 +154,24 @@ public class BoxingBottomSheetActivity extends AbsBoxingActivity implements View
     @Override
     public void onBoxingFinish(Intent intent, @Nullable List<BaseMedia> medias) {
         if (mImage != null && medias != null && !medias.isEmpty()) {
+
+            // Recycle previous image if it was set
+            if (!mImagePath.isEmpty()) {
+                BoxingMediaLoader.getInstance().recycleRaw(mImage, mImagePath);
+            }
+
             ImageMedia imageMedia = (ImageMedia) medias.get(0);
-            BoxingMediaLoader.getInstance().displayRaw(mImage, imageMedia.getPath(), null);
+            mImagePath = imageMedia.getPath();
+            BoxingMediaLoader.getInstance().displayRaw(mImage, mImagePath, null);
         }
         hideBottomSheet();
+    }
+
+    @Override
+    protected void onDestroy() {
+        if (mImage != null && !mImagePath.isEmpty()) {
+            BoxingMediaLoader.getInstance().recycleRaw(mImage, mImagePath);
+        }
+        super.onDestroy();
     }
 }

--- a/boxing-impl/src/main/java/com/bilibili/boxing_impl/ui/BoxingBottomSheetActivity.java
+++ b/boxing-impl/src/main/java/com/bilibili/boxing_impl/ui/BoxingBottomSheetActivity.java
@@ -162,7 +162,7 @@ public class BoxingBottomSheetActivity extends AbsBoxingActivity implements View
 
             ImageMedia imageMedia = (ImageMedia) medias.get(0);
             mImagePath = imageMedia.getPath();
-            BoxingMediaLoader.getInstance().displayRaw(mImage, mImagePath, null);
+            BoxingMediaLoader.getInstance().displayRaw(mImage, mImagePath, 1080, 720, null);
         }
         hideBottomSheet();
     }

--- a/boxing-impl/src/main/java/com/bilibili/boxing_impl/ui/BoxingRawImageFragment.java
+++ b/boxing-impl/src/main/java/com/bilibili/boxing_impl/ui/BoxingRawImageFragment.java
@@ -80,7 +80,11 @@ public class BoxingRawImageFragment extends Fragment {
         mAttacher = new PhotoViewAttacher(mImageView);
         mAttacher.setRotatable(true);
         mAttacher.setToRightAngle(true);
-        ((AbsBoxingViewActivity) getActivity()).loadRawImage(mImageView, mMedia.getPath(), new BoxingCallback(this));
+
+        final AbsBoxingViewActivity activity = (AbsBoxingViewActivity) getActivity();
+        if (activity != null) {
+            activity.loadRawImage(mImageView, mMedia.getPath(), new BoxingCallback(this));
+        }
     }
 
     private void dismissProgressDialog() {
@@ -103,12 +107,17 @@ public class BoxingRawImageFragment extends Fragment {
 
     @Override
     public void onDestroyView() {
-        super.onDestroyView();
         if (mAttacher != null) {
             mAttacher.cleanup();
             mAttacher = null;
+
+            final AbsBoxingViewActivity activity = (AbsBoxingViewActivity) getActivity();
+            if (activity != null) {
+                activity.recycleRawImage(mImageView, mMedia.getPath());
+            }
             mImageView = null;
         }
+        super.onDestroyView();
     }
 
     private static class BoxingCallback implements IBoxingCallback {

--- a/boxing-impl/src/main/java/com/bilibili/boxing_impl/view/MediaItemLayout.java
+++ b/boxing-impl/src/main/java/com/bilibili/boxing_impl/view/MediaItemLayout.java
@@ -21,6 +21,7 @@ import android.content.Context;
 import android.content.res.Configuration;
 import android.graphics.drawable.Drawable;
 import android.support.annotation.NonNull;
+import android.support.v7.widget.RecyclerView;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.view.LayoutInflater;
@@ -30,6 +31,8 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import com.bilibili.boxing.BoxingMediaLoader;
+import com.bilibili.boxing.loader.IBoxingMediaLoader;
+import com.bilibili.boxing.loader.IBoxingMediaRecyclingLoader;
 import com.bilibili.boxing.model.entity.BaseMedia;
 import com.bilibili.boxing.model.entity.impl.ImageMedia;
 import com.bilibili.boxing.model.entity.impl.VideoMedia;
@@ -50,6 +53,7 @@ public class MediaItemLayout extends FrameLayout {
     private View mFontLayout;
     private ImageView mCoverImg;
     private ScreenType mScreenType;
+    private String mCoverImagePath = "";
 
     private enum ScreenType {
         SMALL(100), NORMAL(180), LARGE(320);
@@ -126,13 +130,15 @@ public class MediaItemLayout extends FrameLayout {
     public void setMedia(BaseMedia media) {
         if (media instanceof ImageMedia) {
             mVideoLayout.setVisibility(GONE);
-            setCover(((ImageMedia) media).getThumbnailPath());
+            mCoverImagePath = ((ImageMedia) media).getThumbnailPath();
+            setCover(mCoverImagePath);
         } else if (media instanceof VideoMedia) {
             mVideoLayout.setVisibility(VISIBLE);
             VideoMedia videoMedia = (VideoMedia) media;
             ((TextView) mVideoLayout.findViewById(R.id.video_duration_txt)).setText(videoMedia.getDuration());
             ((TextView) mVideoLayout.findViewById(R.id.video_size_txt)).setText(videoMedia.getSizeByUnit());
-            setCover(videoMedia.getPath());
+            mCoverImagePath = videoMedia.getPath();
+            setCover(mCoverImagePath);
         }
     }
 
@@ -142,6 +148,14 @@ public class MediaItemLayout extends FrameLayout {
         }
         mCoverImg.setTag(R.string.boxing_app_name, path);
         BoxingMediaLoader.getInstance().displayThumbnail(mCoverImg, path, mScreenType.getValue(), mScreenType.getValue());
+    }
+
+    /**
+     * Should be called when the current media item has been recycled (e.g. when {@link android.support.v7.widget.RecyclerView.Adapter#onViewRecycled(RecyclerView.ViewHolder)} was triggered).
+     */
+    public void recycleMedia() {
+        if (mCoverImg == null || mCoverImagePath.isEmpty()) return;
+        BoxingMediaLoader.getInstance().recycleThumbnail(mCoverImg, mCoverImagePath);
     }
 
     @SuppressWarnings("deprecation")

--- a/boxing/src/main/java/com/bilibili/boxing/AbsBoxingViewActivity.java
+++ b/boxing/src/main/java/com/bilibili/boxing/AbsBoxingViewActivity.java
@@ -27,6 +27,8 @@ import android.support.v7.app.AppCompatActivity;
 import android.widget.ImageView;
 
 import com.bilibili.boxing.loader.IBoxingCallback;
+import com.bilibili.boxing.loader.IBoxingMediaLoader;
+import com.bilibili.boxing.loader.IBoxingMediaRecyclingLoader;
 import com.bilibili.boxing.model.BoxingManager;
 import com.bilibili.boxing.model.config.BoxingConfig;
 import com.bilibili.boxing.model.entity.AlbumEntity;
@@ -119,6 +121,16 @@ public abstract class AbsBoxingViewActivity extends AppCompatActivity implements
 
     public final void loadRawImage(@NonNull ImageView img, @NonNull String path, IBoxingCallback callback) {
         BoxingMediaLoader.getInstance().displayRaw(img, path, callback);
+    }
+
+    /**
+     * Recycles the raw image if the current media loader implements {@link IBoxingMediaRecyclingLoader}, does nothing otherwise.
+     *
+     * @param img  The image view containing the raw resource.
+     * @param path The absolute path to the resource.
+     */
+    public final void recycleRawImage(@NonNull ImageView img, @NonNull String path) {
+        BoxingMediaLoader.getInstance().recycleRaw(img, path);
     }
 
     /**

--- a/boxing/src/main/java/com/bilibili/boxing/BoxingMediaLoader.java
+++ b/boxing/src/main/java/com/bilibili/boxing/BoxingMediaLoader.java
@@ -22,6 +22,7 @@ import android.widget.ImageView;
 
 import com.bilibili.boxing.loader.IBoxingCallback;
 import com.bilibili.boxing.loader.IBoxingMediaLoader;
+import com.bilibili.boxing.loader.IBoxingMediaRecyclingLoader;
 
 /**
  * A loader holding {@link IBoxingMediaLoader} to displayThumbnail medias.
@@ -55,6 +56,46 @@ public class BoxingMediaLoader {
             throw new IllegalStateException("init method should be called first");
         }
         mLoader.displayRaw(img, path, callback);
+    }
+
+    /**
+     * Called when the thumbnail should be recycled.
+     *
+     * <p>
+     *  <b>Note:</b> Do nothing if the loader does not implement {@link IBoxingMediaRecyclingLoader}.
+     * </p>
+     *
+     * @param img  The {@link ImageView} with the thumbnail to recycle.
+     * @param path The absolute path to the recycled resource.
+     */
+    public void recycleThumbnail(@NonNull ImageView img, @NonNull String path) {
+        if (ensureLoader()) {
+            throw new IllegalStateException("init method should be called first");
+        }
+
+        if (mLoader instanceof IBoxingMediaRecyclingLoader) {
+            ((IBoxingMediaRecyclingLoader) mLoader).recycleThumbnail(img, path);
+        }
+    }
+
+    /**
+     * Called when the image resource should be recycled.
+     *
+     * <p>
+     * <b>Note:</b> Do nothing if the loader does not implement {@link IBoxingMediaRecyclingLoader}.
+     * </p>
+     *
+     * @param img  The {@link ImageView} with the raw image to recycle.
+     * @param path The absolute path to the recycled resource.
+     */
+    public void recycleRaw(@NonNull ImageView img, @NonNull String path) {
+        if (ensureLoader()) {
+            throw new IllegalStateException("init method should be called first");
+        }
+
+        if (mLoader instanceof IBoxingMediaRecyclingLoader) {
+            ((IBoxingMediaRecyclingLoader) mLoader).recycleRaw(img, path);
+        }
     }
 
     public IBoxingMediaLoader getLoader() {

--- a/boxing/src/main/java/com/bilibili/boxing/loader/IBoxingMediaLoader.java
+++ b/boxing/src/main/java/com/bilibili/boxing/loader/IBoxingMediaLoader.java
@@ -29,7 +29,7 @@ public interface IBoxingMediaLoader {
     /**
      * display thumbnail images for a ImageView.
      *
-     * @param img     the display ImageView. Through ImageView.getTag(R.string.app_name) to get the absolute path of the exact path to display.
+     * @param img     the display ImageView. Through ImageView.getTag(R.string.boxing_app_name) to get the absolute path of the exact path to display.
      * @param absPath the absolute path to display, may be out of date when fast scrolling.
      * @param width   the resize with for the image.
      * @param height  the resize height for the image.
@@ -39,7 +39,7 @@ public interface IBoxingMediaLoader {
     /**
      * display raw images for a ImageView, need more work to do.
      *
-     * @param img      the display ImageView.Through ImageView.getTag(R.string.app_name) to get the absolute path of the exact path to display.
+     * @param img      the display ImageView.Through ImageView.getTag(R.string.boxing_app_name) to get the absolute path of the exact path to display.
      * @param absPath  the absolute path to display, may be out of date when fast scrolling.
      * @param callback the callback for the load result.
      */

--- a/boxing/src/main/java/com/bilibili/boxing/loader/IBoxingMediaRecyclingLoader.java
+++ b/boxing/src/main/java/com/bilibili/boxing/loader/IBoxingMediaRecyclingLoader.java
@@ -1,0 +1,31 @@
+package com.bilibili.boxing.loader;
+
+import android.support.annotation.NonNull;
+import android.widget.ImageView;
+
+/**
+ * Defines the additional methods to recycle the resources associated with the destroyed media objects.
+ */
+public interface IBoxingMediaRecyclingLoader extends IBoxingMediaLoader {
+    /**
+     * Called when the image view containing the thumbnail is no longer valid (e.g. `onViewRecycled` in the recycler view has been triggered).
+     * <p>
+     * <b>Note:</b> If you are using `Glide` then call `Glide.clear(img)` here.
+     * </p>
+     *
+     * @param img     The {@link ImageView} which holds the thumbnail.
+     * @param absPath The absolute path to the thumbnail image.
+     */
+    void recycleThumbnail(@NonNull ImageView img, @NonNull String absPath);
+
+    /**
+     * Called when the image view containing the raw image is no longer valid (e.g. the fragment has been destroyed).
+     * <p>
+     * <b>Note:</b> If you are using `Glide` then call `Glide.clear(img)` here.
+     * </p>
+     *
+     * @param img     The {@link ImageView} which holds the raw (big) image resource.
+     * @param absPath The absolute path to the image resource.
+     */
+    void recycleRaw(@NonNull ImageView img, @NonNull String absPath);
+}


### PR DESCRIPTION
Sometimes it can be useful to make additional clean-up when `onViewRecycled` was called. For example, when using Glide it is [recommended](http://stackoverflow.com/a/40073839/6113810) to call `Glide.clear(imageView)` in `onViewRecycled` to save the memory and improve `Bitmap` reuse.

So I added a new public interface `IBoxingMediaRecyclingLoader` which provides two helpful methods: `recycleThumbnail` and `recycleRaw`. This interface is completely optional. If the users are not interested in recycling they can continue to use the default `IBoxingMediaLoader`.  On the other hand, when the users want to be notified about recycling events they can just change `IBoxingMediaLoader` to `IBoxingMediaRecyclingLoader` like this:

```Java
public class BoxingGlideLoader implements IBoxingMediaRecyclingLoader {

    ...

    @Override
    public void recycleThumbnail(@NonNull ImageView img, @NonNull String absPath) {
        Glide.clear(img);
    }

    @Override
    public void recycleRaw(@NonNull ImageView img, @NonNull String absPath) {
        Glide.clear(img);
    }
}
```